### PR TITLE
update: update version of react-scripts to ^5.0.0

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -12,7 +12,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.1.1",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.0",
     "web-vitals": "^1.0.1"
   },
   "scripts": {


### PR DESCRIPTION
在高版本的nodejs下，打包fe文件夹会出现如下报错。通过升级react-scripts依赖到5.0.0以解决这个问题。
![image](https://github.com/aliyunvideo/ICE_WebSDK_demos/assets/48620706/4f456668-9d76-49b1-a934-beccf7a6fd6c)
